### PR TITLE
Add request management service

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This toolkit simplifies regulatory compliance for startups and businesses operat
   - Right to restrict processing
   - Right to data portability
   - Dashboard for data controllers to manage requests
+  - Local storage requestService to track and update requests in demos
 
 ### 3. Privacy Policy Generator
 - Interactive wizard to create NDPR-compliant privacy policies
@@ -41,6 +42,9 @@ This toolkit simplifies regulatory compliance for startups and businesses operat
 - Workflow for documenting breach details
 - Timeline tracking to ensure 72-hour notification compliance
 - Notification delivery to authorities via API (if available)
+### 6. Data Subject Request Service
+- Lightweight requestService storing requests in browser localStorage for demos
+- Helper methods to update request status and retrieve history
 
 ## Getting Started
 

--- a/src/__tests__/requestService.test.ts
+++ b/src/__tests__/requestService.test.ts
@@ -1,0 +1,44 @@
+import requestService from '@/lib/requestService';
+import { RequestStatus } from '@/types';
+
+describe('requestService', () => {
+  beforeEach(() => {
+    const localStorageMock = (() => {
+      let store: Record<string, string> = {};
+      return {
+        getItem: (key: string) => (key in store ? store[key] : null),
+        setItem: (key: string, value: string) => {
+          store[key] = value;
+        },
+        removeItem: (key: string) => {
+          delete store[key];
+        },
+        clear: () => {
+          store = {};
+        }
+      };
+    })();
+
+    Object.defineProperty(window, 'localStorage', {
+      value: localStorageMock,
+      writable: true,
+    });
+    requestService.clear();
+  });
+
+  test('creates and retrieves a request', () => {
+    const req = requestService.createRequest('access', 'John Doe', 'john@example.com', 'details', true);
+    const stored = requestService.getRequest(req.id);
+    expect(stored).not.toBeNull();
+    expect(stored?.requestType).toBe('access');
+    expect(stored?.status).toBe('pending');
+  });
+
+  test('updates request status', () => {
+    const req = requestService.createRequest('erasure', 'Jane', 'jane@example.com', 'erase', true);
+    const updated = requestService.updateStatus(req.id, 'completed');
+    expect(updated?.status).toBe('completed');
+    const stored = requestService.getRequest(req.id);
+    expect(stored?.status).toBe('completed');
+  });
+});

--- a/src/lib/requestService.ts
+++ b/src/lib/requestService.ts
@@ -1,0 +1,76 @@
+'use client';
+
+import { DataSubjectRequest, RequestStatus } from '@/types';
+import { v4 as uuidv4 } from 'uuid';
+
+const REQUEST_STORAGE_KEY = 'ndpr_requests';
+
+const getStoredRequests = (): DataSubjectRequest[] => {
+  if (typeof window === 'undefined') return [];
+  const stored = localStorage.getItem(REQUEST_STORAGE_KEY);
+  if (!stored) return [];
+  try {
+    return JSON.parse(stored) as DataSubjectRequest[];
+  } catch (error) {
+    console.error('Error parsing requests:', error);
+    return [];
+  }
+};
+
+export const requestService = {
+  createRequest: (
+    requestType: DataSubjectRequest['requestType'],
+    requesterName: string,
+    requesterEmail: string,
+    details: string,
+    consent: boolean
+  ): DataSubjectRequest => {
+    const request: DataSubjectRequest = {
+      id: uuidv4(),
+      requestType,
+      requesterId: uuidv4(),
+      requesterEmail,
+      requesterName,
+      status: 'pending',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      hasConsent: consent,
+      notes: details,
+    };
+
+    if (typeof window !== 'undefined') {
+      const requests = getStoredRequests();
+      requests.push(request);
+      localStorage.setItem(REQUEST_STORAGE_KEY, JSON.stringify(requests));
+    }
+
+    return request;
+  },
+
+  updateStatus: (id: string, status: RequestStatus): DataSubjectRequest | null => {
+    if (typeof window === 'undefined') return null;
+    const requests = getStoredRequests();
+    const idx = requests.findIndex(r => r.id === id);
+    if (idx === -1) return null;
+    requests[idx].status = status;
+    requests[idx].updatedAt = new Date().toISOString();
+    localStorage.setItem(REQUEST_STORAGE_KEY, JSON.stringify(requests));
+    return requests[idx];
+  },
+
+  getRequest: (id: string): DataSubjectRequest | null => {
+    const requests = getStoredRequests();
+    return requests.find(r => r.id === id) || null;
+  },
+
+  getAllRequests: (): DataSubjectRequest[] => {
+    return getStoredRequests();
+  },
+
+  clear: (): void => {
+    if (typeof window === 'undefined') return;
+    localStorage.removeItem(REQUEST_STORAGE_KEY);
+  },
+};
+
+export default requestService;


### PR DESCRIPTION
## Summary
- add `requestService` for demo storage of data subject requests
- document request tracking in README
- test requestService functionality

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: `jest` not found)*
- `npx tsc --noEmit` *(fails: missing dependencies)*