### PR TITLE
Fix Jest config to resolve @testing-library/dom

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,14 @@
 const nextJest = require('next/jest');
+const path = require('path');
+
+// Resolve @testing-library/dom from within @testing-library/react's installation
+// so Jest can find it without having the dependency explicitly installed at the
+// top level. This avoids module resolution errors when running tests.
+const domPath = path.dirname(
+  require.resolve('@testing-library/dom/package.json', {
+    paths: [require.resolve('@testing-library/react/package.json')],
+  })
+);
 
 const createJestConfig = nextJest({
   // Provide the path to your Next.js app to load next.config.js and .env files in your test environment
@@ -11,6 +21,7 @@ const customJestConfig = {
   testEnvironment: 'jest-environment-jsdom',
   moduleNameMapper: {
     // Handle module aliases (if you have them in tsconfig.json)
+    '^@testing-library/dom$': domPath,
     '^@/(.*)$': '<rootDir>/src/$1',
   },
   testPathIgnorePatterns: [


### PR DESCRIPTION
## Summary
- avoid module resolution errors in tests
- dynamically resolve `@testing-library/dom` so Jest can find it

## Testing
- `npm test`